### PR TITLE
Generalize building slots

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,29 +11,29 @@
         <div id="planets-container"></div> 
 
         <div id="mining-base">
-            <div class="factory-slot">
-                <div id="factory-plot-0" class="factory-plot buildable" data-slot-index="0"></div>
+            <div class="build-slot">
+                <div id="build-plot-0" class="build-plot" data-slot-index="0"></div>
             </div>
-            <div class="factory-slot">
-                <div id="factory-plot-1" class="factory-plot buildable" data-slot-index="1"></div>
+            <div class="build-slot">
+                <div id="build-plot-1" class="build-plot" data-slot-index="1"></div>
             </div>
-            <div class="factory-slot">
-                <div id="factory-plot-2" class="factory-plot buildable" data-slot-index="2"></div>
+            <div class="build-slot">
+                <div id="build-plot-2" class="build-plot" data-slot-index="2"></div>
             </div>
-            <div class="factory-slot">
-                <div id="factory-plot-3" class="factory-plot buildable" data-slot-index="3"></div>
+            <div class="build-slot">
+                <div id="build-plot-3" class="build-plot" data-slot-index="3"></div>
             </div>
-            <div class="factory-slot">
-                <div id="factory-plot-4" class="factory-plot buildable" data-slot-index="4"></div>
+            <div class="build-slot">
+                <div id="build-plot-4" class="build-plot" data-slot-index="4"></div>
             </div>
-            <div class="factory-slot">
-                <div id="factory-plot-5" class="factory-plot buildable" data-slot-index="5"></div>
+            <div class="build-slot">
+                <div id="build-plot-5" class="build-plot" data-slot-index="5"></div>
             </div>
-            <div class="factory-slot">
-                <div id="factory-plot-6" class="factory-plot buildable" data-slot-index="6"></div>
+            <div class="build-slot">
+                <div id="build-plot-6" class="build-plot" data-slot-index="6"></div>
             </div>
-             <div class="factory-slot">
-                <div id="trade-post-plot-0" class="trade-post-plot buildable" data-slot-index="7"></div>
+            <div class="build-slot">
+                <div id="build-plot-7" class="build-plot" data-slot-index="7"></div>
             </div>
         </div>
         
@@ -69,7 +69,8 @@
                 <h3>Baumenü</h3>
                 <p>Wähle, was du bauen möchtest.</p>
                 <button id="build-factory-button" class="game-button">Fabrik bauen (Kosten: 10 Score)</button>
-                <button id="build-trade-post-button" class="game-button hidden">Handelsposten bauen (Kosten: 50 Score)</button> <button id="close-build-menu-button" class="game-button close-button">Schließen</button>
+                <button id="build-trade-post-button" class="game-button">Handelsposten bauen (Kosten: 50 Score)</button>
+                <button id="close-build-menu-button" class="game-button close-button">Schließen</button>
             </div>
         </div>
 

--- a/js/GameManager.js
+++ b/js/GameManager.js
@@ -164,12 +164,12 @@ class GameManager {
 
         // Factory Build Button
         if (this.ui.elements.buildFactoryButton && this.factoryManager) {
-            this.factoryManager.updateBuildButtonState(this.score, this.ui.elements.buildFactoryButton, this.ui.currentFactorySlotIndex);
+            this.factoryManager.updateBuildButtonState(this.score, this.ui.elements.buildFactoryButton, this.ui.currentSlotIndex);
         }
 
         // Trade Post Build Button
         if (this.ui.elements.buildTradePostButton && this.tradeManager) {
-            this.tradeManager.updateBuildButtonState(this.score, this.ui.elements.buildTradePostButton);
+            this.tradeManager.updateBuildButtonState(this.score, this.ui.elements.buildTradePostButton, this.ui.currentSlotIndex);
         }
 
         // Factory Upgrade Buttons

--- a/js/UI.js
+++ b/js/UI.js
@@ -6,7 +6,7 @@ class UI {
     constructor() {
         this.elements = {}; // Speichert alle DOM-Element-Referenzen
         this.gameUnitPx = 1; // 1 game unit in Pixeln (wird dynamisch gesetzt)
-        this.currentFactorySlotIndex = -1; // Für Build Menu Logic
+        this.currentSlotIndex = -1; // Für Build Menu Logic
         this.currentSelectedFactory = null; // Aktuell ausgewähltes Fabrikobjekt für Upgrade-Menü
         this.currentSelectedTradePost = null; // Aktuell ausgewähltes Handelspostenobjekt für Upgrade-Menü
 
@@ -41,20 +41,16 @@ class UI {
         this.elements.upgradeStorageButton = document.getElementById('upgrade-storage-button');
         this.elements.upgradeCollectorYieldButton = document.getElementById('upgrade-collector-yield-button');
 
-        this.elements.factoryPlotElements = [];
-        // Die Schleife muss jetzt alle Fabrik-Slots von 0 bis maxSlots-1 erfassen
-        for (let i = 0; i < CONFIG.Factories.maxSlots; i++) {
-            const plotElement = document.getElementById(`factory-plot-${i}`);
+        this.elements.buildPlotElements = [];
+        const totalSlots = CONFIG.TradePost.slotIndex + 1;
+        for (let i = 0; i < totalSlots; i++) {
+            const plotElement = document.getElementById(`build-plot-${i}`);
             if (plotElement) {
-                this.elements.factoryPlotElements.push(plotElement);
+                this.elements.buildPlotElements.push(plotElement);
             } else {
-                // Diese Warnung sollte jetzt nur noch für wirklich fehlende IDs erscheinen,
-                // nicht mehr für den Handelsposten-Plot, wenn dieser eine andere ID hat.
-                log(`[WARNING] UI.initDOMElements: Factory plot with ID factory-plot-${i} not found.`);
+                log(`[WARNING] UI.initDOMElements: Build plot with ID build-plot-${i} not found.`);
             }
         }
-        // Der Handelsposten-Plot wird weiterhin separat geholt
-        this.elements.tradePostPlotElement = document.getElementById(`trade-post-plot-0`);
 
         this.elements.buildMenu = document.getElementById('build-menu');
         this.elements.buildFactoryButton = document.getElementById('build-factory-button');
@@ -173,21 +169,15 @@ class UI {
     /**
      * Zeigt das Build-Menü an einem bestimmten Slot an.
      * @param {number} slotIndex - Der Index des Slots.
-     * @param {'factory'|'tradePost'} type - Der Typ des Gebäudes, das gebaut werden soll.
      * @param {GameManager} gameManager - Instanz des GameManager.
      */
-    showBuildMenu(slotIndex, type, gameManager) {
-        this.currentFactorySlotIndex = slotIndex;
+    showBuildMenu(slotIndex, gameManager) {
+        this.currentSlotIndex = slotIndex;
         this.elements.buildMenu.classList.remove('hidden');
-        if (type === 'factory') {
-            this.elements.buildFactoryButton.classList.remove('hidden');
-            if (this.elements.buildTradePostButton) this.elements.buildTradePostButton.classList.add('hidden');
-        } else if (type === 'tradePost') {
-            this.elements.buildFactoryButton.classList.add('hidden');
-            if (this.elements.buildTradePostButton) this.elements.buildTradePostButton.classList.remove('hidden');
-        }
+        if (this.elements.buildFactoryButton) this.elements.buildFactoryButton.classList.remove('hidden');
+        if (this.elements.buildTradePostButton) this.elements.buildTradePostButton.classList.remove('hidden');
         gameManager.checkButtonStates(); // Buttons im Build-Menü aktualisieren
-        log(`Showing build menu for slot ${slotIndex}, type: ${type}`);
+        log(`Showing build menu for slot ${slotIndex}`);
     }
 
     /**
@@ -195,7 +185,7 @@ class UI {
      */
     hideBuildMenu() {
         this.elements.buildMenu.classList.add('hidden');
-        this.currentFactorySlotIndex = -1;
+        this.currentSlotIndex = -1;
         log('Build menu hidden.');
     }
 

--- a/js/main.js
+++ b/js/main.js
@@ -79,12 +79,8 @@ function performInit() {
     UI.elements.upgradeStorageButton.addEventListener('click', () => GameManager.upgradeStorage());
     UI.elements.upgradeGoodsStorageButton.addEventListener('click', () => GameManager.upgradeGoodsStorage());
 
-    // Fabrik und Handelsposten Bau/Upgrade Listener
+    // Bauplatz Listener
     FactoryManager.initializePlotListeners();
-    // Der Handelsposten-Plot-Listener ist Teil des TradeManager
-    if (UI.elements.tradePostPlotElement) {
-        UI.elements.tradePostPlotElement.addEventListener('click', () => UI.showBuildMenu(CONFIG.TradePost.slotIndex, 'tradePost', GameManager));
-    }
 
     // Build Menu Buttons
     UI.elements.buildFactoryButton.addEventListener('click', () => FactoryManager.buildFactory());

--- a/js/managers/FactoryManager.js
+++ b/js/managers/FactoryManager.js
@@ -30,25 +30,22 @@ class FactoryManager {
      * Fügt Event Listener zu den Fabrik-Bauplätzen hinzu.
      */
     initializePlotListeners() {
-        this.ui.elements.factoryPlotElements.forEach(plot => {
-            // Sicherstellen, dass der Plot nicht der Handelsposten-Plot ist (dessen Listener separat behandelt wird)
-            if (plot.id !== 'trade-post-plot-0') {
-                plot.addEventListener('click', () => this.ui.showBuildMenu(parseInt(plot.dataset.slotIndex), 'factory', this.gameManager));
-            }
+        this.ui.elements.buildPlotElements.forEach(plot => {
+            plot.addEventListener('click', () => this.ui.showBuildMenu(parseInt(plot.dataset.slotIndex), this.gameManager));
         });
-        log('Factory plot event listeners added.');
+        log('Build plot event listeners added.');
     }
 
     /**
      * Baut eine neue Fabrik an einem bestimmten Slot.
      */
     buildFactory() {
-        const slotIndex = this.ui.currentFactorySlotIndex;
+        const slotIndex = this.ui.currentSlotIndex;
         if (slotIndex === -1) return;
 
-        const targetPlot = document.getElementById(`factory-plot-${slotIndex}`);
+        const targetPlot = document.getElementById(`build-plot-${slotIndex}`);
         if (!targetPlot) {
-            log(`[ERROR] FactoryManager.buildFactory: Target plot factory-plot-${slotIndex} not found!`);
+            log(`[ERROR] FactoryManager.buildFactory: Target plot build-plot-${slotIndex} not found!`);
             return;
         }
 

--- a/js/managers/TradeManager.js
+++ b/js/managers/TradeManager.js
@@ -33,19 +33,15 @@ class TradeManager {
      * Baut den Handelsposten an seinem vorgesehenen Slot.
      */
     buildTradePost() {
-        const slotIndex = this.ui.currentFactorySlotIndex; // Der UI hält den aktuell ausgewählten Slot
-        if (slotIndex !== CONFIG.TradePost.slotIndex) {
-            log(`[ERROR] TradeManager.buildTradePost: Attempted to build Trade Post in wrong slot: ${slotIndex}. Expected: ${CONFIG.TradePost.slotIndex}`);
-            return;
-        }
+        const slotIndex = this.ui.currentSlotIndex; // Der UI hält den aktuell ausgewählten Slot
         if (this.tradePost !== null) {
             log("Trade Post is already built.");
             return;
         }
 
-        const targetPlot = this.ui.elements.tradePostPlotElement;
+        const targetPlot = document.getElementById(`build-plot-${slotIndex}`);
         if (!targetPlot) {
-            log("[ERROR] TradeManager.buildTradePost: Trade post plot element not found for building!");
+            log("[ERROR] TradeManager.buildTradePost: Build plot element not found for building!");
             return;
         }
 
@@ -58,7 +54,7 @@ class TradeManager {
 
             targetPlot.parentNode.replaceChild(tradePostElement, targetPlot);
 
-            this.tradePost = new TradePost(tradePostElement, CONFIG.TradePost.slotIndex);
+            this.tradePost = new TradePost(tradePostElement, slotIndex);
 
             tradePostElement.addEventListener('click', () => {
                 this.ui.showTradePostUpgradeMenu(this.tradePost);
@@ -171,9 +167,12 @@ class TradeManager {
      * @param {number} currentScore - Aktueller Score des Spielers.
      * @param {HTMLElement} buildTradePostButton - Der Button.
      */
-    updateBuildButtonState(currentScore, buildTradePostButton) {
+    updateBuildButtonState(currentScore, buildTradePostButton, slotIndex) {
         const hasTradePost = this.tradePost !== null;
-        buildTradePostButton.disabled = currentScore < CONFIG.TradePost.buildCost || hasTradePost;
+        const factoryManager = this.gameManager.factoryManager;
+        const slotOccupied = factoryManager ? factoryManager.factories.some(f => f.slotIndex === slotIndex) : false;
+        const slotHasTrade = this.tradePost && this.tradePost.slotIndex === slotIndex;
+        buildTradePostButton.disabled = currentScore < CONFIG.TradePost.buildCost || hasTradePost || slotOccupied || slotHasTrade;
         // Text-Aktualisierung findet bereits im GameManager.checkButtonStates statt
     }
 

--- a/style.css
+++ b/style.css
@@ -281,8 +281,8 @@ body {
     cursor: not-allowed;
 }
 
-/* --- Fabrik-bezogene Stile --- */
-.factory-slot {
+/* --- Bauplatz-Stile --- */
+.build-slot {
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -294,7 +294,7 @@ body {
     flex-shrink: 0;
 }
 
-.factory-plot {
+.build-plot {
     width: 100%;
     height: 100%;
     border: calc(0.5 * var(--game-unit)) dashed #007bff;
@@ -310,7 +310,7 @@ body {
     box-sizing: border-box;
 }
 
-.factory-plot::before {
+.build-plot::before {
     content: "Bauplatz";
 }
 
@@ -358,28 +358,6 @@ body {
     height: 100%;
     width: 0%;
     background-color: #33aaff;
-}
-
-
-/* NEU: Handelsposten-bezogene Stile */
-.trade-post-plot {
-    width: 100%;
-    height: 100%;
-    border: calc(0.5 * var(--game-unit)) dashed #ffc107; /* Orange gestrichelt */
-    background-color: rgba(255, 193, 7, 0.1);
-    cursor: pointer;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-size: calc(1.2 * var(--game-unit));
-    color: #ffc107;
-    text-align: center;
-    border-radius: calc(1 * var(--game-unit));
-    box-sizing: border-box;
-}
-
-.trade-post-plot::before {
-    content: "Handelsposten Bauplatz";
 }
 
 .trade-post {


### PR DESCRIPTION
## Summary
- use generic build slots instead of factory/trade-post specific slots
- update UI logic to show build menu with both options
- allow building trade posts on any free slot

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68840ddbb1ac83328797920e3040440a