### PR TITLE
Fix planet spawn overlapping UI

### DIFF
--- a/js/managers/PlanetManager.js
+++ b/js/managers/PlanetManager.js
@@ -27,6 +27,44 @@ class PlanetManager {
     }
 
     /**
+     * Prüft, ob eine Planetenposition mit UI-Elementen kollidiert.
+     * @param {number} x_percent - X-Position des Planetenmittelpunkts in Prozent.
+     * @param {number} y_percent - Y-Position des Planetenmittelpunkts in Prozent.
+     * @param {number} sizePercent - Größe des Planeten in Prozent.
+     * @returns {boolean} True, wenn eine Überschneidung mit der UI vorliegt.
+     */
+    isOverlappingUI(x_percent, y_percent, sizePercent) {
+        if (!this.ui || !this.ui.elements) return false;
+
+        const half = sizePercent / 2;
+        const planetRect = {
+            left: x_percent - half,
+            right: x_percent + half,
+            top: y_percent - half,
+            bottom: y_percent + half,
+        };
+
+        const elementsToCheck = [
+            this.ui.elements.scoreDisplay,
+            this.ui.elements.collectorCountDisplay,
+            this.ui.elements.storageDisplay,
+            this.ui.elements.storageArea,
+            this.ui.elements.goodsDisplay,
+            this.ui.elements.goodsArea,
+        ];
+
+        return elementsToCheck.some(el => {
+            if (!el) return false;
+            const { x, y, width, height } = this.ui.getElementTopLeftInPercent(el);
+            const rect = { left: x, right: x + width, top: y, bottom: y + height };
+            return !(planetRect.right < rect.left ||
+                     planetRect.left > rect.right ||
+                     planetRect.bottom < rect.top ||
+                     planetRect.top > rect.bottom);
+        });
+    }
+
+    /**
      * Erstellt einen neuen Planeten und fügt ihn dem Spiel hinzu.
      * @returns {Planet} Das neu erstellte Planetenobjekt.
      */
@@ -37,11 +75,24 @@ class PlanetManager {
 
         const planetSizePercent = CONFIG.Planets.sizePercent;
 
-        const x_percent = Math.random() * (100 - planetSizePercent) + (planetSizePercent / 2);
         const y_min_percent = CONFIG.Planets.spawnAreaTopRelative * 100;
         const y_max_percent = CONFIG.Planets.spawnAreaBottomRelative * 100;
-        const y_percent = Math.random() * (y_max_percent - y_min_percent - planetSizePercent) + y_min_percent + (planetSizePercent / 2);
 
+        let x_percent;
+        let y_percent;
+        let attempts = 0;
+        const maxAttempts = 50;
+
+        do {
+            x_percent = Math.random() * (100 - planetSizePercent) + (planetSizePercent / 2);
+            y_percent = Math.random() * (y_max_percent - y_min_percent - planetSizePercent) +
+                y_min_percent + (planetSizePercent / 2);
+            attempts++;
+        } while (this.isOverlappingUI(x_percent, y_percent, planetSizePercent) && attempts < maxAttempts);
+
+        if (attempts >= maxAttempts) {
+            log(`[WARNING] spawnPlanet: Could not find non-overlapping position after ${attempts} attempts.`);
+        }
 
         el.style.left = `${x_percent - (planetSizePercent / 2)}%`;
         el.style.top = `${y_percent - (planetSizePercent / 2)}%`;


### PR DESCRIPTION
## Summary
- add UI overlap check when spawning planets
- retry random spawn position up to 50 attempts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884188ba054833297c16e371ea51d92