### PR TITLE
Add Jest setup with basic tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "idle_game_entwurf",
+  "version": "1.0.0",
+  "description": "",
+  "main": "script.js",
+  "scripts": {
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/tests/gameManager.test.js
+++ b/tests/gameManager.test.js
@@ -1,0 +1,35 @@
+import { CONFIG } from '../js/config.js';
+
+function createDOM() {
+  return {
+    scoreDisplay: document.createElement('div'),
+    storageDisplay: document.createElement('div'),
+    goodsDisplay: document.createElement('div'),
+    storageFill: document.createElement('div'),
+    goodsFill: document.createElement('div'),
+    ui: { elements: {} }
+  };
+}
+
+test('updateScore adjusts score and display', async () => {
+  jest.resetModules();
+  const { default: gameManager } = await import('../js/GameManager.js');
+  const dom = createDOM();
+  gameManager.init(dom.scoreDisplay, dom.storageDisplay, dom.goodsDisplay, dom.storageFill, dom.goodsFill, dom.ui);
+  gameManager.updateScore(5);
+  expect(gameManager.getScore()).toBe(CONFIG.Game.initialScore + 5);
+  expect(dom.scoreDisplay.textContent).toBe(`Score: ${CONFIG.Game.initialScore + 5}`);
+});
+
+test('upgradeStorage increases capacity and decreases score', async () => {
+  jest.resetModules();
+  const { default: gameManager } = await import('../js/GameManager.js');
+  const dom = createDOM();
+  gameManager.init(dom.scoreDisplay, dom.storageDisplay, dom.goodsDisplay, dom.storageFill, dom.goodsFill, dom.ui);
+  const startMax = gameManager.getMaxStorage();
+  const startScore = gameManager.getScore();
+  const cost = CONFIG.Storage.upgradeCost;
+  gameManager.upgradeStorage();
+  expect(gameManager.getMaxStorage()).toBe(Math.ceil(startMax * CONFIG.Storage.upgradeCapacityMultiplier));
+  expect(gameManager.getScore()).toBe(startScore - cost);
+});

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,28 @@
+import { log, checkInitialLoad } from '../js/utils/Utils.js';
+import { CONFIG } from '../js/config.js';
+
+/** Simple helper to mock offset properties on an element */
+function mockDimensions(el, width = 10, height = 10) {
+  Object.defineProperty(el, 'offsetWidth', { get: () => width });
+  Object.defineProperty(el, 'offsetHeight', { get: () => height });
+}
+
+test('log outputs message when debugMode is true', () => {
+  CONFIG.Game.debugMode = true;
+  const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  log('Hello World', 123);
+  expect(spy).toHaveBeenCalledWith(expect.stringContaining('Hello World'), 123);
+  spy.mockRestore();
+});
+
+test('checkInitialLoad invokes callback when elements are ready', () => {
+  const game = document.createElement('div');
+  const planets = document.createElement('div');
+  const base = document.createElement('div');
+  mockDimensions(game); 
+  mockDimensions(planets); 
+  mockDimensions(base);
+  const cb = jest.fn();
+  checkInitialLoad(game, planets, base, cb);
+  expect(cb).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add package.json with Jest configuration and test script
- add tests for utilities and game manager logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68841f1ba4c88332bf146af1dce38846