### PR TITLE
Add level system with upgrade button

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
             </div>
             <div class="button-column">
                 <button id="upgrade-goods-storage-button" class="game-button">Güterlager erweitern (Kosten: 75)</button>
+                <button id="next-level-button" class="game-button">Raumschiff verbessern</button>
             </div>
         </div>
 

--- a/js/GameManager.js
+++ b/js/GameManager.js
@@ -1,10 +1,11 @@
 // js/GameManager.js
 import { CONFIG } from './config.js';
 import { log } from './utils/Utils.js';
+import LevelManager from './managers/LevelManager.js';
 
 class GameManager {
     constructor() {
-        this.score = CONFIG.Game.initialScore;
+        this.score = CONFIG.Game.initialScore * LevelManager.level;
         this.currentStorage = CONFIG.Game.initialStorage;
         this.maxStorage = CONFIG.Game.initialMaxStorage;
         this.currentGoods = CONFIG.Goods.initialGoods;
@@ -45,6 +46,13 @@ class GameManager {
         this.storageFill = storageFill;
         this.goodsFill = goodsFill;
         this.ui = ui;
+
+        // Startwerte basierend auf aktuellem Level
+        this.score = CONFIG.Game.initialScore * LevelManager.level;
+        this.currentStorage = CONFIG.Game.initialStorage;
+        this.maxStorage = CONFIG.Game.initialMaxStorage;
+        this.currentGoods = CONFIG.Goods.initialGoods;
+        this.maxGoods = CONFIG.Goods.initialMaxGoods;
 
         // Initialisiere Anzeigen
         this.updateScore(0);

--- a/js/UI.js
+++ b/js/UI.js
@@ -35,6 +35,7 @@ class UI {
         this.elements.goodsArea = document.getElementById('goods-area');
         this.elements.goodsFill = document.getElementById('goods-fill');
         this.elements.upgradeGoodsStorageButton = document.getElementById('upgrade-goods-storage-button');
+        this.elements.nextLevelButton = document.getElementById('next-level-button');
 
         this.elements.buyCollectorButton = document.getElementById('buy-collector-button');
         this.elements.upgradeCollectorSpeedButton = document.getElementById('upgrade-collector-speed-button');

--- a/js/main.js
+++ b/js/main.js
@@ -7,6 +7,7 @@ import PlanetManager from './managers/PlanetManager.js';
 import CollectorManager from './managers/CollectorManager.js';
 import FactoryManager from './managers/FactoryManager.js';
 import TradeManager from './managers/TradeManager.js';
+import LevelManager from './managers/LevelManager.js';
 
 // Globale DOM-Elemente für den Initialisierungscheck
 let gameContainerForLoadCheck;
@@ -44,6 +45,7 @@ function performInit() {
 
     // UI-Elemente zuweisen (UI.js kümmert sich um document.getElementById)
     UI.initDOMElements();
+    LevelManager.init(UI);
 
     // GameManager mit den benötigten UI-Referenzen initialisieren
     GameManager.init(
@@ -78,6 +80,9 @@ function performInit() {
     UI.elements.upgradeCollectorYieldButton.addEventListener('click', () => CollectorManager.upgradeCollectorYield());
     UI.elements.upgradeStorageButton.addEventListener('click', () => GameManager.upgradeStorage());
     UI.elements.upgradeGoodsStorageButton.addEventListener('click', () => GameManager.upgradeGoodsStorage());
+    if (UI.elements.nextLevelButton) {
+        UI.elements.nextLevelButton.addEventListener('click', () => LevelManager.advanceLevel());
+    }
 
     // Bauplatz Listener
     FactoryManager.initializePlotListeners();

--- a/js/managers/LevelManager.js
+++ b/js/managers/LevelManager.js
@@ -1,0 +1,73 @@
+import { CONFIG } from '../config.js';
+
+const BASE_COSTS = {
+    collectorBuy: 10,
+    collectorSpeed: 20,
+    collectorYield: 10,
+    storageUpgrade: 50,
+    goodsUpgrade: 75,
+    factoryBuild: 10,
+    factoryYieldUpgrade: 10,
+    factorySpeedUpgrade: 20,
+    tradeBuild: 50,
+    tradePriceUpgrade: 20,
+    tradeSpeedUpgrade: 30,
+};
+
+class LevelManager {
+    constructor() {
+        this.level = parseInt(localStorage.getItem('gameLevel')) || 1;
+        this.ui = null;
+    }
+
+    init(ui) {
+        this.ui = ui;
+        this.applyCostMultiplier();
+        this.applyLevelVisuals();
+    }
+
+    getCostMultiplier() {
+        return this.level + 1;
+    }
+
+    applyCostMultiplier() {
+        const m = this.getCostMultiplier();
+        CONFIG.Collectors.buyCost = BASE_COSTS.collectorBuy * m;
+        CONFIG.Collectors.speedUpgradeCost = BASE_COSTS.collectorSpeed * m;
+        CONFIG.Collectors.yieldUpgradeCost = BASE_COSTS.collectorYield * m;
+        CONFIG.Storage.upgradeCost = BASE_COSTS.storageUpgrade * m;
+        CONFIG.Goods.upgradeCost = BASE_COSTS.goodsUpgrade * m;
+        CONFIG.Factories.buildCost = BASE_COSTS.factoryBuild * m;
+        CONFIG.Factories.initialYieldUpgradeCost = BASE_COSTS.factoryYieldUpgrade * m;
+        CONFIG.Factories.initialSpeedUpgradeCost = BASE_COSTS.factorySpeedUpgrade * m;
+        CONFIG.TradePost.buildCost = BASE_COSTS.tradeBuild * m;
+        CONFIG.TradePost.initialPriceUpgradeCost = BASE_COSTS.tradePriceUpgrade * m;
+        CONFIG.TradePost.initialSpeedUpgradeCost = BASE_COSTS.tradeSpeedUpgrade * m;
+    }
+
+    applyLevelVisuals() {
+        if (!this.ui) return;
+        const sizeMultiplier = 1 + 0.1 * (this.level - 1);
+        const width = 40 * sizeMultiplier;
+        const height = 24 * sizeMultiplier;
+        this.ui.elements.miningBase.style.width = `calc(${width} * var(--game-unit))`;
+        this.ui.elements.miningBase.style.height = `calc(${height} * var(--game-unit))`;
+
+        const unlocked = this.level + 1; // level 1 => 2 slots
+        this.ui.elements.buildPlotElements.forEach((el, idx) => {
+            const container = el.parentElement;
+            if (container) {
+                container.style.display = idx < unlocked ? 'flex' : 'none';
+            }
+        });
+    }
+
+    advanceLevel() {
+        this.level += 1;
+        localStorage.setItem('gameLevel', this.level);
+        window.location.reload();
+    }
+}
+
+const levelManager = new LevelManager();
+export default levelManager;


### PR DESCRIPTION
## Summary
- add new button to advance to the next level
- implement `LevelManager` to handle level state, cost scaling and visual changes
- adjust UI to reference the new button
- hook level logic into game initialization and button events
- update `GameManager` to start with level-dependent values

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688547e51b048332a30c5ba5eb85135b